### PR TITLE
ci(nightly): on-change + weekly instead of daily

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,7 +2,11 @@ name: Nightly Validation
 
 on:
   schedule:
-    - cron: '23 4 * * *'
+    # Weekly full validation: Sunday 04:23 UTC (catches environment drift)
+    - cron: '23 4 * * 0'
+  push:
+    # On-change: run full suite on every push to main/dev
+    branches: [main, dev]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary

- Switch nightly validation from daily (04:23 UTC every day) to **on-change + weekly**
- Weekly schedule (Sunday 04:23 UTC) catches environment drift (base image updates, dependency changes)
- Push to main/dev triggers the full test suite (full-live, slow, ARM smoke) on every real code change
- CI workflow (`ci.yml`) continues to handle lightweight PR/push feedback independently

## Motivation

GitHub Actions Free plan provides 2,000 min/month. The daily nightly was consuming **~1,590 min/month** (80% of quota) running 3 parallel jobs every night regardless of code changes.

**Projected savings:** ~1,590 → ~320 min/month (on-change ~4-8×/month + weekly 4×/month).

## Test plan

- [ ] Verify the weekly cron fires correctly on Sunday
- [ ] Verify push to main triggers the nightly workflow
- [ ] Verify CI workflow still triggers independently on push/PR
- [ ] Monitor Actions usage for the next billing cycle

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)