### PR TITLE
fix(security): Restrict sandbox loopback access to proxy and DNS only

### DIFF
--- a/src/services/sandbox/egress_firewall.py
+++ b/src/services/sandbox/egress_firewall.py
@@ -10,7 +10,8 @@ direct TCP from a malicious skill — bypass the proxy entirely.
 
 This module installs iptables OUTPUT rules that match on the sandbox uid:
   - ALLOW the sandbox uid → 127.0.0.1:<proxy_port>  (so pip etc. work)
-  - DROP everything else from the sandbox uid
+  - ALLOW the sandbox uid → 127.0.0.53:53 (DNS via systemd-resolved)
+  - REJECT everything else from the sandbox uid
 
 The API process itself runs as root (uid 0), so the proxy's own outbound
 traffic to PyPI/npm/etc. is unaffected by these rules.
@@ -113,10 +114,8 @@ def install_sandbox_egress_rules(sandbox_uid: int, proxy_port: int) -> bool:
             "-j",
             "ACCEPT",
         ],
-        # Allow loopback traffic generally (DNS to systemd-resolved on 127.0.0.53,
-        # localhost-only services, etc.). The proxy enforces hostname allowlist
-        # for actual outbound; this just keeps the sandbox uid able to talk
-        # to itself if it ever needs to.
+        # Allow DNS to systemd-resolved on loopback (some tools resolve
+        # before handing the CONNECT to the proxy).
         [
             "-A",
             "OUTPUT",
@@ -124,8 +123,32 @@ def install_sandbox_egress_rules(sandbox_uid: int, proxy_port: int) -> bool:
             "owner",
             "--uid-owner",
             str(sandbox_uid),
-            "-o",
-            "lo",
+            "-d",
+            "127.0.0.53",
+            "-p",
+            "udp",
+            "--dport",
+            "53",
+            "-m",
+            "comment",
+            "--comment",
+            _RULE_COMMENT,
+            "-j",
+            "ACCEPT",
+        ],
+        [
+            "-A",
+            "OUTPUT",
+            "-m",
+            "owner",
+            "--uid-owner",
+            str(sandbox_uid),
+            "-d",
+            "127.0.0.53",
+            "-p",
+            "tcp",
+            "--dport",
+            "53",
             "-m",
             "comment",
             "--comment",


### PR DESCRIPTION
## Summary

When `ENABLE_SANDBOX_NETWORK=true`, nsjail disables the network namespace clone (`--disable_clone_newnet`) so sandbox processes share the container's network namespace. The egress firewall is supposed to lock sandboxes down to only the allowlist proxy, but an overly broad iptables rule (`-o lo -j ACCEPT`) granted sandbox processes access to **every port on loopback** — including the API itself on `127.0.0.1:8000`.

This PR replaces the blanket loopback rule with targeted rules that only allow DNS resolution (`127.0.0.53:53` UDP/TCP).

## Vulnerability Details

**Root cause:** `src/services/sandbox/egress_firewall.py` line 120–135 contained:
```
-A OUTPUT -m owner --uid-owner <sandbox_uid> -o lo -j ACCEPT
```
This was intended for DNS and "localhost-only services" but inadvertently opened all 65,535 loopback ports to the sandbox UID.

**Attack path (demonstrated on the live dev instance):**

1. Submit a Python execution request with `ENABLE_SANDBOX_NETWORK=true`:
   ```python
   import urllib.request, ssl
   ctx = ssl.create_default_context()
   ctx.check_hostname = False
   ctx.verify_mode = ssl.CERT_NONE
   resp = urllib.request.urlopen("https://127.0.0.1:8000/health", timeout=5, context=ctx)
   print(resp.status, resp.read().decode())
   ```
2. **Result:** `200 {"status":"healthy","version":"1.2.0","service":"code-interpreter-api"}` — sandbox code reached the API.

3. A port scan from inside the sandbox confirmed:
   | Port | Service | Status |
   |------|---------|--------|
   | 8000 | API (HTTPS) | **OPEN** |
   | 18443 | Egress Proxy | OPEN (intended) |
   | 6379 | Redis | Closed (separate container) |
   | 3900 | Garage/S3 | Closed (separate container) |

4. With `AUTH_ENABLED=true` (current config), calling `/exec` from the sandbox returns 401 — auth blocks escalation. However, if `AUTH_ENABLED=false` (a documented, supported configuration for trusted-network deployments), sandbox code would get **full unauthenticated API access**: executing code in other sessions, accessing other sessions' files, etc.

**Mitigating factors:**
- `ENABLE_SANDBOX_NETWORK` defaults to `false` — only affects deployments that enable it for skill installs
- `AUTH_ENABLED` defaults to `true` — full escalation requires auth to be disabled
- nsjail PID/mount namespace isolation prevents the API key from being discoverable via `/proc` or environment variables

## What Changed

**`src/services/sandbox/egress_firewall.py`** — replaced one rule with two:

| Before | After |
|--------|-------|
| `-o lo -j ACCEPT` (all loopback ports) | `-d 127.0.0.53 -p udp --dport 53 -j ACCEPT` (DNS only) |
| | `-d 127.0.0.53 -p tcp --dport 53 -j ACCEPT` (DNS over TCP) |

The existing rule #1 (proxy port on `127.0.0.1`) and rule #3 (REJECT everything else) are unchanged. The net effect is that the sandbox UID can now only reach:
- `127.0.0.1:<proxy_port>` — the egress allowlist proxy (pip, npm, go, cargo)
- `127.0.0.53:53` — DNS resolution via systemd-resolved

All other loopback ports (including 8000/API) are now rejected.

## Test Plan

- [x] `pytest tests/unit/test_egress_proxy.py` — 21 tests pass
- [x] `flake8` and `black --check` clean
- [ ] Rebuild container and re-run the sandbox loopback test — `urllib.request.urlopen("https://127.0.0.1:8000/health")` should fail with connection refused/rejected
- [ ] Verify skill installs still work (`pip install`, `npm install`) through the proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)